### PR TITLE
`exec ('echo $HOME')` is "$HOME" in win32 (DOS, *sniff*)

### DIFF
--- a/packager.php
+++ b/packager.php
@@ -1,7 +1,7 @@
 <?php
 
 require dirname(__FILE__) . "/helpers/yaml.php";
-require dirname(__FILE__) . "/helpers/array.php";
+if (!function_exists('array_get')) require dirname(__FILE__) . "/helpers/array.php";
 
 Class Packager {
 	


### PR DESCRIPTION
I'm not exactly sure of the best cross platform, but this worked for Win. 
