### PR TITLE
Sources patterns

### DIFF
--- a/packager.php
+++ b/packager.php
@@ -65,7 +65,7 @@ class Packager {
 			$patternUsed = true;
  		}
 
-		if ( !empty($manifest['sources']) ) $this->overall = $manifest['sources'];
+		if ( !empty($manifest['overall']) ) $this->overall = $manifest['overall'];
 
 		foreach ($manifest['sources'] as $i => $path){
 

--- a/packager.php
+++ b/packager.php
@@ -65,7 +65,7 @@ class Packager {
 			$patternUsed = true;
  		}
 
-		if ( !empty($manifest['overall']) ) $this->overall = $manifest['overall'];
+		if ( !empty($manifest['overall']) ) $this->overall = $package_path . $manifest['overall'];
 
 		foreach ($manifest['sources'] as $i => $path){
 

--- a/packager.php
+++ b/packager.php
@@ -3,21 +3,6 @@
 require dirname(__FILE__) . "/helpers/yaml.php";
 require dirname(__FILE__) . "/helpers/array.php";
 
-function bfglob($path, $pattern = '*', $flags = 0, $depth = 0) {
-	$matches = array();
-	$folders = array(rtrim($path, DIRECTORY_SEPARATOR));
-     
-	while($folder = array_shift($folders)) {
-	$matches = array_merge($matches, glob($folder.DIRECTORY_SEPARATOR.$pattern, $flags));
-		if($depth != 0) {
-			$moreFolders = glob($folder.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
-			$depth   = ($depth < -1) ? -1: $depth + count($moreFolders) - 2;
-			$folders = array_merge($folders, $moreFolders);
-		}
-	}
-	return $matches;
-}
-
 class Packager {
 	
 	public static function warn($message){
@@ -75,7 +60,7 @@ class Packager {
 		$this->manifests[$package_name] = $manifest;
 
 		if(!is_array($manifest['sources'])){
-			$manifest['sources'] = bfglob($package_path, $manifest['sources'], 0, 5);
+			$manifest['sources'] = $this->bfglob($package_path, $manifest['sources'], 0, 5);
 			$patternUsed = true;
  		}
 		foreach ($manifest['sources'] as $i => $path){
@@ -134,6 +119,21 @@ class Packager {
 		if ($length == 1) return array($default, $exploded[0]);
 		if (empty($exploded[0])) return array($default, $exploded[1]);
 		return array($exploded[0], $exploded[1]);
+	}
+
+	private	function bfglob($path, $pattern = '*', $flags = 0, $depth = 0) {
+		$matches = array();
+		$folders = array(rtrim($path, DIRECTORY_SEPARATOR));
+	     
+		while($folder = array_shift($folders)) {
+		$matches = array_merge($matches, glob($folder.DIRECTORY_SEPARATOR.$pattern, $flags));
+			if($depth != 0) {
+				$moreFolders = glob($folder.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR);
+				$depth   = ($depth < -1) ? -1: $depth + count($moreFolders) - 2;
+				$folders = array_merge($folders, $moreFolders);
+			}
+		}
+		return $matches;
 	}
 	
 	// # private HASHES

--- a/packager.php
+++ b/packager.php
@@ -11,9 +11,10 @@ class Packager {
 		fclose($std_err);
 	}
 
-	private $packages = array();
+	private $wrappers  = array();
+	private $packages  = array();
 	private $manifests = array();
-	private $root = null;
+	private $root      = null;
 	
 	public function __construct($package_paths){
 		foreach ((array)$package_paths as $package_path) $this->parse_manifest($package_path);
@@ -58,13 +59,27 @@ class Packager {
 		$manifest['manifest'] = $manifest_path;
 		
 		$this->manifests[$package_name] = $manifest;
-
+		
 		if(!is_array($manifest['sources'])){
 			$manifest['sources'] = $this->bfglob($package_path, $manifest['sources'], 0, 5);
 			$patternUsed = true;
  		}
-		foreach ($manifest['sources'] as $i => $path){
+
+		$wrappers = array( 'intro', 'outro' );
+
+		foreach ($wrappers as $key => $type) {
+			$value = empty($manifest[$type]) ?
+				null : $package_path . $manifest[$type];
+			$this->wrappers[$type] = $wrappers[$key] = $value;
+		}
 		
+		foreach ($manifest['sources'] as $i => $path){
+
+			if (array_contains( $wrappers, $path )) {
+				unset($manifest['sources'][$i]);
+				continue;
+			}
+
 			if(!isset($patternUsed)) $path = $package_path . $path;
 			
 			// this is where we "hook" for possible other replacers.
@@ -99,7 +114,6 @@ class Packager {
 			));
 
 		}
-
 	}
 	
 	public function add_package($package_path){
@@ -181,6 +195,10 @@ class Packager {
 	public function package_exists($name){
 		return array_contains($this->get_packages(), $name);
 	}
+
+	public function get_wrapper_source ($outro) {
+		return file_get_contents( $this->wrappers[$outro ? 'outro' : 'intro'] );
+	}
 	
 	public function validate($more_files = array(), $more_components = array(), $more_packages = array()){
 
@@ -235,7 +253,7 @@ class Packager {
 			$source = preg_replace_callback("%(/[/*])\s*<$block>(.*?)</$block>(?:\s*\*/)?%s", array($this, "block_replacement"), $source);
 		}
 		
-		return $source . "\n";
+		return $this->get_wrapper_source(false) . $source . $this->get_wrapper_source(true) . "\n";
 	}
 	
 	private function block_replacement($matches){


### PR DESCRIPTION
You don't need to push right file names into "source" section in package.yml anymore, you can do:
    name: "project"
    exports: "project.js"
    description: "project"
    copyright: "2010 &copy;" 
    author: "slik"
    sources: *.js
