### PR TITLE
Describe a component (or file) in the sources section of the manifest

### DIFF
--- a/packager.php
+++ b/packager.php
@@ -61,6 +61,11 @@ Class Packager {
 		
 		foreach ($manifest['sources'] as $i => $path){
 			
+			// thomasd: if the source-node contains a description we cache it, but we wait if there's also a description-header in the file as this one takes precedence
+			if(is_array($path)){
+				$source_desc = $path[1];
+				$path = $path[0];
+			}
 			$path = $package_path . $path;
 			
 			// this is where we "hook" for possible other replacers.
@@ -71,7 +76,13 @@ Class Packager {
 			// get contents of first comment
 			preg_match('/\/\*\s*^---(.*?)^\.\.\.\s*\*\//ms', $source, $matches);
 
-			if (!empty($matches)) $descriptor = YAML::decode($matches[0]);
+			if (!empty($matches)){
+				$descriptor = YAML::decode($matches[0]);
+			}
+			// thomasd: if the file doesn't contain a proper description-header but the manifest does, we take that description 
+			else if(isset($source_desc) && is_array($source_desc)){
+				$descriptor = $source_desc;
+			}
 
 			// populate / convert to array requires and provides
 			$requires = (array)(!empty($descriptor['requires']) ? $descriptor['requires'] : array());


### PR DESCRIPTION
For frequently changing external files (libraries, widgets...) which do not follow the mootools package-syntax and have no description-header in their files, I added the ability to describe the components of a file in the manifest file. 

Example:
    name: "Core"
    exports: "mootools-core.js"
    web: "[mootools.net](http://mootools.net)"
    description: "MooTools, The JavaScript framework"
    license: "[MIT License](http://mootools.net/license.txt)"
    copyright: "&copy; [MooTools](http://mootools.net)"
    authors: "[MooTools Development Team](http://mootools.net/developers)"

```
sources:
  - "Source/Core/Core.js"
  - 
    - "Source/Types/Array.js"
    - name: Array
      description: Contains Array Prototypes like each, contains, and erase.
      license: MIT-style license.
      requires: Type
      provides: Array
  - "Source/Types/String.js"
```

Having the description in the manifest the actual source file doesn't need a header.
I decided to handle the file path and the description in an array with 2 elements, but it may also be possible and maybe easier to read if you handle that in a map using the file path as key and the description map as value?!
